### PR TITLE
Fix typo for IPv4 (0x8000 -> 0x0800)

### DIFF
--- a/tuntap/tun.go
+++ b/tuntap/tun.go
@@ -29,7 +29,7 @@ const (
 
 type Packet struct {
 	// The Ethernet type of the packet. Commonly seen values are
-	// 0x8000 for IPv4 and 0x86dd for IPv6.
+	// 0x0800 for IPv4 and 0x86dd for IPv6.
 	Protocol int
 	// True if the packet was too large to be read completely.
 	Truncated bool


### PR DESCRIPTION
IPv4 Ethertype is 0x800, not 0x8000
