### PR TITLE
Remove trailing 0-bytes in Interface name on Linux

### DIFF
--- a/tuntap/tun_linux.go
+++ b/tuntap/tun_linux.go
@@ -1,9 +1,10 @@
 package tuntap
 
 import (
+	"bytes"
 	"os"
-	"unsafe"
 	"syscall"
+	"unsafe"
 )
 
 func openDevice(ifPattern string) (*os.File, error) {
@@ -31,5 +32,9 @@ func createInterface(file *os.File, ifPattern string, kind DevKind, meta bool) (
 	if err != 0 {
 		return "", err
 	}
-	return string(req.Name[:]), nil
+	idxNull := bytes.IndexByte(req.Name[:], 0)
+	if idxNull < 0 {
+		idxNull = len(req.Name)
+	}
+	return string(req.Name[:idxNull]), nil
 }


### PR DESCRIPTION
The interface name as returned by the TUNSETIFF ioctl on Linux is a 16 bytes long byte array which is padded with 0-bytes. In contrast to C, go can handle 0-bytes in strings and as a result comparing i.e. "tun0" with what is returned from that function fails because the returned string is acutally "tun0\x00\x00\x00..".
This PR fixes the problem by truncating the returned string at the first 0-byte as a C string handling function would do.

Signed-off-by: Christian Pointner <equinox@spreadspace.org>

