### PR TITLE
Fix the example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ Usage
 
     func main () {
         var tund *tuntap.Interface
-        var erro error
+        var err error
         var inpkt *tuntap.Packet
 
-        tund, err = tuntap.Open("tun0", tuntap.DevTun)
-        inpkt = tund.ReadPacket()
+        tun_metahdr := false
+        tund, err  = tuntap.Open("tun0", tuntap.DevTun, tun_metahdr)
+        inpkt, err = tund.ReadPacket()
     }
 
 

--- a/print_tuntap/print_tuntap.go
+++ b/print_tuntap/print_tuntap.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"code.google.com/p/tuntap"
+	"github.com/lab11/go-tuntap/tuntap"
 )
 
 func main() {
@@ -25,7 +25,7 @@ func main() {
 		return
 	}
 
-	tun, err := tuntap.Open(os.Args[2], typ)
+	tun, err := tuntap.Open(os.Args[2], typ, false)
 	if err != nil {
 		fmt.Println("Error opening tun/tap device:", err)
 		return


### PR DESCRIPTION
The README and the print_tuntap example program both don't use the "meta"
required argument to tuntap.Open()